### PR TITLE
Check Element propType for non-browser environments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { string, func, number, bool, shape, node, oneOfType, instanceOf,  } from 'prop-types';
+import { any, string, func, number, bool, shape, node, oneOfType, instanceOf,  } from 'prop-types';
 
 import formatCurrency from './format-currency';
 
@@ -180,7 +180,7 @@ IntlCurrencyInput.propTypes = {
   onKeyPress: func.isRequired,
   inputRef: oneOfType([
     func,
-    shape({ current: instanceOf(Element) })
+    shape({ current: (typeof Element === 'undefined' ? any : instanceOf(Element)) })
   ])
 };
 


### PR DESCRIPTION
O tipo `Element` não tá disponível em projetos SSR (tipo o Next.JS), porque o NodeJS não inclui o DOM, o que causa o erro "ReferenceError: Element is not defined".
Uma alternativa é quando o `Element` for undefined, fazer fallback pro `any`.